### PR TITLE
Update sim to build

### DIFF
--- a/sim/build.rs
+++ b/sim/build.rs
@@ -13,12 +13,11 @@ fn main() {
     conf.file("../boot/bootutil/src/bootutil_misc.c");
     conf.file("csupport/run.c");
     conf.include("../boot/bootutil/include");
-    conf.include("../zephyr/include");
+    conf.include("../boot/zephyr/include");
     conf.debug(true);
     conf.compile("libbootutil.a");
     walk_dir("../boot").unwrap();
     walk_dir("csupport").unwrap();
-    walk_dir("../zephyr").unwrap();
 }
 
 // Output the names of all files within a directory so that Cargo knows when to rebuild.

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -143,9 +143,11 @@ fn main() {
            bad, total_count,
            bad as f32 * 100.0 / total_count as f32);
 
-    info!("Try revert");
-    let fl2 = try_revert(&flash, &areadesc);
-    assert!(verify_image(&fl2, 0x020000, &primary));
+    for count in 2 .. 5 {
+        info!("Try revert: {}", count);
+        let fl2 = try_revert(&flash, &areadesc, count);
+        assert!(verify_image(&fl2, 0x020000, &primary));
+    }
 
     info!("Try norevert");
     let fl2 = try_norevert(&flash, &areadesc);
@@ -194,12 +196,13 @@ fn try_upgrade(flash: &Flash, areadesc: &AreaDesc, stop: Option<i32>) -> (Flash,
     (fl, cnt2)
 }
 
-fn try_revert(flash: &Flash, areadesc: &AreaDesc) -> Flash {
+fn try_revert(flash: &Flash, areadesc: &AreaDesc, count: usize) -> Flash {
     let mut fl = flash.clone();
     c::set_flash_counter(0);
 
-    assert_eq!(c::boot_go(&mut fl, &areadesc), 0);
-    assert_eq!(c::boot_go(&mut fl, &areadesc), 0);
+    for _ in 0 .. count {
+        assert_eq!(c::boot_go(&mut fl, &areadesc), 0);
+    }
     fl
 }
 


### PR DESCRIPTION
Bring in some commits to properly find source dependencies when building the simulator, and to properly build with the 'zephyr' change previously committed.

There is also an additional enhancement to test multiple reverts that the swap only happens one additional time to revert, and there is no re-reverting.